### PR TITLE
Fix the batch test script; fix GettingStarted build.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ obj/
 packages/
 *.suo
 .nuget/
+TestResults/

--- a/bigquery/api/GettingStarted/BigQuery.csproj
+++ b/bigquery/api/GettingStarted/BigQuery.csproj
@@ -50,8 +50,8 @@
       <HintPath>packages\Google.Apis.Auth.1.9.3\lib\net40\Google.Apis.Auth.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Bigquery.v2, Version=1.9.2.234, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>packages\Google.Apis.Bigquery.v2.1.9.2.2340\lib\portable-net40+sl50+win+wpa81+wp80\Google.Apis.Bigquery.v2.dll</HintPath>
+    <Reference Include="Google.Apis.Bigquery.v2, Version=1.9.2.238, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>packages\Google.Apis.Bigquery.v2.1.9.2.2380\lib\portable-net40+sl50+win+wpa81+wp80\Google.Apis.Bigquery.v2.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Apis.Core, Version=1.9.3.19379, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
@@ -115,14 +115,6 @@
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-  </Target>
-  <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/bigquery/api/GettingStarted/packages.config
+++ b/bigquery/api/GettingStarted/packages.config
@@ -3,7 +3,7 @@
   <package id="BouncyCastle" version="1.7.0" targetFramework="net45" />
   <package id="Google.Apis" version="1.9.3" targetFramework="net45" />
   <package id="Google.Apis.Auth" version="1.9.3" targetFramework="net45" />
-  <package id="Google.Apis.Bigquery.v2" version="1.9.2.2340" targetFramework="net45" />
+  <package id="Google.Apis.Bigquery.v2" version="1.9.2.2380" targetFramework="net45" />
   <package id="Google.Apis.Core" version="1.9.3" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />

--- a/bigquery/api/GettingStarted/test/packages.config
+++ b/bigquery/api/GettingStarted/test/packages.config
@@ -3,7 +3,7 @@
   <package id="BouncyCastle" version="1.7.0" targetFramework="net45" />
   <package id="Google.Apis" version="1.9.3" targetFramework="net45" />
   <package id="Google.Apis.Auth" version="1.9.3" targetFramework="net45" />
-  <package id="Google.Apis.Bigquery.v2" version="1.9.2.2340" targetFramework="net45" />
+  <package id="Google.Apis.Bigquery.v2" version="1.9.2.2380" targetFramework="net45" />
   <package id="Google.Apis.Core" version="1.9.3" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
   <package id="Microsoft.Bcl" version="1.1.10" targetFramework="net45" />

--- a/bigquery/api/GettingStarted/test/test.csproj
+++ b/bigquery/api/GettingStarted/test/test.csproj
@@ -53,8 +53,8 @@
       <HintPath>..\packages\Google.Apis.Auth.1.9.3\lib\net40\Google.Apis.Auth.PlatformServices.dll</HintPath>
       <Private>True</Private>
     </Reference>
-    <Reference Include="Google.Apis.Bigquery.v2, Version=1.9.2.234, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
-      <HintPath>..\packages\Google.Apis.Bigquery.v2.1.9.2.2340\lib\portable-net40+sl50+win+wpa81+wp80\Google.Apis.Bigquery.v2.dll</HintPath>
+    <Reference Include="Google.Apis.Bigquery.v2, Version=1.9.2.238, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
+      <HintPath>..\packages\Google.Apis.Bigquery.v2.1.9.2.2380\lib\portable-net40+sl50+win+wpa81+wp80\Google.Apis.Bigquery.v2.dll</HintPath>
       <Private>True</Private>
     </Reference>
     <Reference Include="Google.Apis.Core, Version=1.9.3.19379, Culture=neutral, PublicKeyToken=4b01fa6e34db77ab, processorArchitecture=MSIL">
@@ -149,14 +149,6 @@
   <Import Project="$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets" Condition="Exists('$(VSToolsPath)\TeamTest\Microsoft.TestTools.targets')" />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <Import Project="$(SolutionDir)\.nuget\NuGet.targets" Condition="Exists('$(SolutionDir)\.nuget\NuGet.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Enable NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('$(SolutionDir)\.nuget\NuGet.targets')" Text="$([System.String]::Format('$(ErrorText)', '$(SolutionDir)\.nuget\NuGet.targets'))" />
-    <Error Condition="!Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets'))" />
-  </Target>
-  <Import Project="..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets" Condition="Exists('..\packages\Microsoft.Bcl.Build.1.0.21\build\Microsoft.Bcl.Build.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/buildAndRunTests.bat
+++ b/buildAndRunTests.bat
@@ -3,20 +3,28 @@ SET MSBUILD="%ProgramFiles(x86)%\MSBuild\14.0\Bin\MSBuild.exe"
 SET NUGET="%ProgramFiles(x86)%\MSBuild\14.0\Bin\Nuget.exe"
 SET MSTEST="%ProgramFiles(x86)%\Microsoft Visual Studio 14.0\Common7\IDE\MSTest.exe"
 REM Dump the environment variables.
+SET FAILED=0
 SET
 
 CD bigquery\api\BigQueryUtil
 %NUGET% restore
-%MSBUILD% 
-%MSTEST% /testcontainer:test\bin\debug\test.dll
+%MSBUILD% && %MSTEST% /testcontainer:test\bin\debug\test.dll || SET FAILED=1
 
 CD ..\GettingStarted
 %NUGET% restore
-%MSBUILD% 
-%MSTEST% /testcontainer:test\bin\debug\test.dll
+%MSBUILD% && %MSTEST% /testcontainer:test\bin\debug\test.dll || SET FAILED=1
 
 CD ..\..\..\storage\api
 %NUGET% restore
-%MSBUILD% 
-%MSTEST% /testcontainer:test\bin\debug\test.dll
+%MSBUILD% && %MSTEST% /testcontainer:test\bin\debug\test.dll || SET FAILED=1
+
+@ECHO OFF
+IF %FAILED% NEQ 0 GOTO failed_case
 ENDLOCAL
+ECHO SUCCEEDED
+EXIT /b 
+
+:failed_case
+ENDLOCAL
+ECHO FAILED
+EXIT /b 1


### PR DESCRIPTION
Jenkins was reporting success even when some of the tests had failed, so
add a little logic to the batch script to fix that.
Then, fix the problem with the broken builds.
And add TestResults/ to .gitignore for convenience.